### PR TITLE
Translate Cloudformation API data to EventBridge API data

### DIFF
--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -237,7 +237,9 @@ class CloudFormationResponse(BaseResponse):
                 break
 
         if not resource:
-            message = "Resource {0} does not exist for stack {1}".format(logical_resource_id, stack_name)
+            message = "Resource {0} does not exist for stack {1}".format(
+                logical_resource_id, stack_name
+            )
             raise ValidationError(stack_name, message)
 
         template = self.response_template(DESCRIBE_STACK_RESOURCE_RESPONSE_TEMPLATE)

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -224,6 +224,10 @@ class Rule(CloudFormationModel):
         properties = cloudformation_json["Properties"]
         properties.setdefault("EventBusName", "default")
 
+        if "EventPattern" in properties:
+
+            properties["EventPattern"] = json.dumps(properties["EventPattern"])
+
         event_backend = events_backends[region_name]
         event_name = resource_name
         return event_backend.put_rule(name=event_name, **properties)

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -225,7 +225,6 @@ class Rule(CloudFormationModel):
         properties.setdefault("EventBusName", "default")
 
         if "EventPattern" in properties:
-
             properties["EventPattern"] = json.dumps(properties["EventPattern"])
 
         event_backend = events_backends[region_name]

--- a/tests/test_events/test_events_cloudformation.py
+++ b/tests/test_events/test_events_cloudformation.py
@@ -35,6 +35,33 @@ archive_template = Template(
 )
 
 
+rule_template = Template(
+    json.dumps(
+        {
+            "AWSTemplateFormatVersion": "2010-09-09",
+            "Description": "EventBridge Rule Test",
+            "Resources": {
+                "Rule": {
+                    "Type": "AWS::Events::Rule",
+                    "Properties": {
+                        "Name": "${rule_name}",
+                        "EventPattern": {
+                            "detail-type": ["meteor"]
+                        },
+                    },
+                }
+            },
+            "Outputs": {
+                "Arn": {
+                    "Description": "Rule Arn",
+                    "Value": {"Fn::GetAtt": ["Rule", "Arn"]},
+                }
+            },
+        }
+    )
+)
+
+
 @mock_events
 @mock_cloudformation
 def test_create_archive():
@@ -105,3 +132,28 @@ def test_delete_archive():
     events_client = boto3.client("events", region_name="eu-central-1")
     response = events_client.list_archives(NamePrefix="test")["Archives"]
     response.should.have.length_of(0)
+
+
+@mock_events
+@mock_cloudformation
+def test_create_rule():
+    # given
+    cfn_client = boto3.client("cloudformation", region_name="eu-central-1")
+    name = "test-rule"
+    stack_name = "test-stack"
+    template = rule_template.substitute({"rule_name": name})
+
+    # when
+    cfn_client.create_stack(StackName=stack_name, TemplateBody=template)
+
+    # then
+    rule_arn = "arn:aws:events:eu-central-1:{0}:rule/{1}".format(ACCOUNT_ID, name)
+    stack = cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]
+    stack["Outputs"][0]["OutputValue"].should.equal(rule_arn)
+
+    events_client = boto3.client("events", region_name="eu-central-1")
+    response = events_client.describe_rule(Name=name)
+
+    response["Arn"].should.equal(rule_arn)
+
+

--- a/tests/test_events/test_events_cloudformation.py
+++ b/tests/test_events/test_events_cloudformation.py
@@ -45,9 +45,7 @@ rule_template = Template(
                     "Type": "AWS::Events::Rule",
                     "Properties": {
                         "Name": "${rule_name}",
-                        "EventPattern": {
-                            "detail-type": ["meteor"]
-                        },
+                        "EventPattern": {"detail-type": ["meteor"]},
                     },
                 }
             },
@@ -155,5 +153,3 @@ def test_create_rule():
     response = events_client.describe_rule(Name=name)
 
     response["Arn"].should.equal(rule_arn)
-
-


### PR DESCRIPTION
## Purpose

The CloudFormation API takes a [dictionary for `EventPattern`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#aws-resource-events-rule-syntax), whereas the EventBridge API takes [a string only](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutRule.html#API_PutRule_RequestSyntax). The "real" cloudformation backend must do a translation. This PR emulates that behavior.

## Related Issues

Needed by https://github.com/EBSCOIS/platform.af.nebula/pull/103