### PR TITLE
Add scheduled action cloudformation

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -276,6 +276,98 @@ class FakeLaunchConfiguration(CloudFormationModel):
         return block_device_map
 
 
+class FakeScheduledAction(CloudFormationModel):
+
+    def __init__(
+        self,
+        asg_name,
+        desired_capacity,
+        max_size,
+        min_size,
+        scheduled_action_name=None,
+        start_time=None,
+        end_time=None,
+        recurrence=None
+    ):
+
+        self.asg_name = asg_name
+        self.desired_capacity = desired_capacity
+        self.max_size = max_size
+        self.min_size = min_size
+        self.start_time = start_time
+        self.end_time = end_time
+        self.recurrence = recurrence
+        self.scheduled_action_name = scheduled_action_name
+
+        self.name = scheduled_action_name if scheduled_action_name else "this-name-doesnt-matter"
+
+    @staticmethod
+    def cloudformation_name_type():
+
+        return "ScheduledActionName"
+
+    @staticmethod
+    def cloudformation_type():
+
+        # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-as-scheduledaction.html
+        return "AWS::AutoScaling::ScheduledAction"
+
+    @classmethod
+    def create_from_cloudformation_json(
+        cls, resource_name, cloudformation_json, region_name, **kwargs
+    ):
+
+        # TODO: This should create the scheduled action on the ASG passed
+        #       in the cloudformation_json
+        # TODO: This should validate the allowed cloudformation "Properties"
+
+        kwargs = {}
+
+        properties = cloudformation_json["Properties"]
+
+        if "StartTime" in properties:
+
+            kwargs.update({"start_time": properties["StartTime"]})
+
+        if "EndTime" in properties:
+
+            kwargs.update({"end_time": properties["EndTime"]})
+
+        if "Recurrence" in properties:
+
+            kwargs.update({"recurrence": properties["Recurrence"]})
+
+        return cls(
+            cloudformation_json["Properties"]["AutoScalingGroupName"],
+            cloudformation_json["Properties"]["DesiredCapacity"],
+            cloudformation_json["Properties"]["MaxSize"],
+            cloudformation_json["Properties"]["MinSize"],
+            **kwargs
+        )
+
+    @classmethod
+    def update_from_cloudformation_json(
+        cls, original_resource, new_resource_name, cloudformation_json, region_name
+    ):
+
+        cls.delete_from_cloudformation_json(
+            original_resource.name, cloudformation_json, region_name
+        )
+
+        return cls.create_from_cloudformation_json(
+            new_resource_name, cloudformation_json, region_name
+        )
+
+    @classmethod
+    def delete_from_cloudformation_json(
+        cls, resource_name, cloudformation_json, region_name
+    ):
+
+        # TODO: This should remove the scheduled action from the ASG
+        #       passed in the cloudformation json
+        return None
+
+
 class FakeAutoScalingGroup(CloudFormationModel):
     def __init__(
         self,

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -329,9 +329,9 @@ class FakeScheduledAction(CloudFormationModel):
             max_size=properties.get("MaxSize"),
             min_size=properties.get("MinSize"),
             scheduled_action_name=scheduled_action_name,
-            start_time=start_time.properties("StartTime"),
-            end_time=end_time.properties("EndTime"),
-            recurrence=recurrence.properties("Recurrence"),
+            start_time=properties.get("StartTime"),
+            end_time=properties.get("EndTime"),
+            recurrence=properties.get("Recurrence"),
         )
         return group
 

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -321,11 +321,25 @@ class FakeScheduledAction(CloudFormationModel):
         #       in the cloudformation_json
         # TODO: This should validate the allowed cloudformation "Properties"
 
-        kwargs = {}
-
+        print(f"\n RESOURCE_NAME: {}")
         properties = cloudformation_json["Properties"]
 
-        if "StartTime" in properties:
+        backend = autoscaling_backends[region_name]
+        group = backend.put_scheduled_update_group_action(
+            asg_name=properties.get("AutoScalingGroupName"),
+            desired_capacity=desired_capacity.get("DesiredCapacity"),
+            max_size=max_size.get("MaxSize"),
+            min_size=min_size.get("MinSize"),
+            scheduled_action_name=scheduled_action_name = resource_name
+            start_time=start_time.get("StartTime"),
+            end_time=end_time.get("EndTime"),
+            recurrence=recurrence.get("Recurrence"),
+        )
+        return group
+        kwargs = {}
+
+
+        """if "StartTime" in properties:
 
             kwargs.update({"start_time": properties["StartTime"]})
 
@@ -343,7 +357,38 @@ class FakeScheduledAction(CloudFormationModel):
             cloudformation_json["Properties"]["MaxSize"],
             cloudformation_json["Properties"]["MinSize"],
             **kwargs
+        )"""
+
+    def put_scheduled_update_group_action(
+        asg_name,
+        desired_capacity,
+        max_size,
+        min_size,
+        scheduled_action_name=None,
+        start_time=None,
+        end_time=None,
+        recurrence=None
+    ):
+        def make_int(value):
+            return int(value) if value is not None else value
+
+        max_size = make_int(max_size)
+        min_size = make_int(min_size)
+        desired_capacity = make_int(desired_capacity)
+
+        group = FakeScheduledAction(
+            asg_name=asg_name,
+            desired_capacity=desired_capacity,
+            max_size=max_size,
+            min_size=min_size,
+            scheduled_action_name=scheduled_action_name,
+            start_time=start_time=None,
+            end_time=end_time=None,
+            recurrence=recurrence=None
         )
+        self.autoscaling_groups[name] = group
+
+        return group
 
     @classmethod
     def update_from_cloudformation_json(

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -317,21 +317,18 @@ class FakeScheduledAction(CloudFormationModel):
         cls, resource_name, cloudformation_json, region_name, **kwargs
     ):
 
-        # TODO: This should create the scheduled action on the ASG passed
-        #       in the cloudformation_json
-        # TODO: This should validate the allowed cloudformation "Properties"
-
-        print(f"\n RESOURCE_NAME: {resource_name}")
         properties = cloudformation_json["Properties"]
 
         backend = autoscaling_backends[region_name]
 
+        scheduled_action_name = kwargs["LogicalId"] if kwargs.get("LogicalId") else "ScheduledScalingAction-{random.randint(0,100)}"
+
         group = backend.put_scheduled_update_group_action(
-            asg_name=properties.get("AutoScalingGroupName"),
+            name=properties.get("AutoScalingGroupName"),
             desired_capacity=properties.get("DesiredCapacity"),
             max_size=properties.get("MaxSize"),
             min_size=properties.get("MinSize"),
-            scheduled_action_name = kwargs["LogicalId"],
+            scheduled_action_name=scheduled_action_name,
             start_time.properties("StartTime"),
             end_time.properties("EndTime"),
             recurrence.properties("Recurrence"),
@@ -851,7 +848,7 @@ class AutoScalingBackend(BaseBackend):
 
     def put_scheduled_update_group_action(
         self,
-        asg_name,
+        name,
         desired_capacity,
         max_size,
         min_size,
@@ -868,7 +865,7 @@ class AutoScalingBackend(BaseBackend):
         desired_capacity = make_int(desired_capacity)
 
         group = FakeScheduledAction(
-            asg_name=asg_name,
+            name=name,
             desired_capacity=desired_capacity,
             max_size=max_size,
             min_size=min_size,
@@ -877,7 +874,7 @@ class AutoScalingBackend(BaseBackend):
             end_time=None,
             recurrence=None
         )
-        self.autoscaling_groups[asg_name] = group
+        #self.autoscaling_groups[asg_name] = group
 
         return group
 

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -329,9 +329,9 @@ class FakeScheduledAction(CloudFormationModel):
             max_size=properties.get("MaxSize"),
             min_size=properties.get("MinSize"),
             scheduled_action_name=scheduled_action_name,
-            start_time.properties("StartTime"),
-            end_time.properties("EndTime"),
-            recurrence.properties("Recurrence"),
+            start_time=start_time.properties("StartTime"),
+            end_time=end_time.properties("EndTime"),
+            recurrence=recurrence.properties("Recurrence"),
         )
         return group
 

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -280,7 +280,7 @@ class FakeScheduledAction(CloudFormationModel):
 
     def __init__(
         self,
-        asg_name,
+        name,
         desired_capacity,
         max_size,
         min_size,
@@ -290,7 +290,7 @@ class FakeScheduledAction(CloudFormationModel):
         recurrence=None
     ):
 
-        self.asg_name = asg_name
+        self.name = name
         self.desired_capacity = desired_capacity
         self.max_size = max_size
         self.min_size = min_size
@@ -874,7 +874,7 @@ class AutoScalingBackend(BaseBackend):
             end_time=None,
             recurrence=None
         )
-        #self.autoscaling_groups[asg_name] = group
+        #self.autoscaling_groups[name] = group
 
         return group
 

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -299,7 +299,7 @@ class FakeScheduledAction(CloudFormationModel):
         self.recurrence = recurrence
         self.scheduled_action_name = scheduled_action_name
 
-        self.name = scheduled_action_name if scheduled_action_name else "this-name-doesnt-matter"
+        self.name = scheduled_action_name if scheduled_action_name else "autoscaling-scheduled-action"
 
     @staticmethod
     def cloudformation_name_type():

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -299,7 +299,7 @@ class FakeScheduledAction(CloudFormationModel):
         self.recurrence = recurrence
         self.scheduled_action_name = scheduled_action_name
 
-        self.name = scheduled_action_name if scheduled_action_name else "autoscaling-scheduled-action"
+        #self.scheduled_action_name = scheduled_action_name if scheduled_action_name else "autoscaling-scheduled-action"
 
     @staticmethod
     def cloudformation_name_type():
@@ -321,25 +321,26 @@ class FakeScheduledAction(CloudFormationModel):
         #       in the cloudformation_json
         # TODO: This should validate the allowed cloudformation "Properties"
 
-        print(f"\n RESOURCE_NAME: {}")
+        print(f"\n RESOURCE_NAME: {resource_name}")
         properties = cloudformation_json["Properties"]
 
         backend = autoscaling_backends[region_name]
+
         group = backend.put_scheduled_update_group_action(
             asg_name=properties.get("AutoScalingGroupName"),
-            desired_capacity=desired_capacity.get("DesiredCapacity"),
-            max_size=max_size.get("MaxSize"),
-            min_size=min_size.get("MinSize"),
-            scheduled_action_name=scheduled_action_name = resource_name
-            start_time=start_time.get("StartTime"),
-            end_time=end_time.get("EndTime"),
-            recurrence=recurrence.get("Recurrence"),
+            desired_capacity=properties.get("DesiredCapacity"),
+            max_size=properties.get("MaxSize"),
+            min_size=properties.get("MinSize"),
+            scheduled_action_name = kwargs["LogicalId"],
+            start_time.properties("StartTime"),
+            end_time.properties("EndTime"),
+            recurrence.properties("Recurrence"),
         )
         return group
-        kwargs = {}
 
+        """kwargs = {}
 
-        """if "StartTime" in properties:
+        if "StartTime" in properties:
 
             kwargs.update({"start_time": properties["StartTime"]})
 
@@ -358,37 +359,6 @@ class FakeScheduledAction(CloudFormationModel):
             cloudformation_json["Properties"]["MinSize"],
             **kwargs
         )"""
-
-    def put_scheduled_update_group_action(
-        asg_name,
-        desired_capacity,
-        max_size,
-        min_size,
-        scheduled_action_name=None,
-        start_time=None,
-        end_time=None,
-        recurrence=None
-    ):
-        def make_int(value):
-            return int(value) if value is not None else value
-
-        max_size = make_int(max_size)
-        min_size = make_int(min_size)
-        desired_capacity = make_int(desired_capacity)
-
-        group = FakeScheduledAction(
-            asg_name=asg_name,
-            desired_capacity=desired_capacity,
-            max_size=max_size,
-            min_size=min_size,
-            scheduled_action_name=scheduled_action_name,
-            start_time=start_time=None,
-            end_time=end_time=None,
-            recurrence=recurrence=None
-        )
-        self.autoscaling_groups[name] = group
-
-        return group
 
     @classmethod
     def update_from_cloudformation_json(
@@ -878,6 +848,38 @@ class AutoScalingBackend(BaseBackend):
 
     def delete_launch_configuration(self, launch_configuration_name):
         self.launch_configurations.pop(launch_configuration_name, None)
+
+    def put_scheduled_update_group_action(
+        self,
+        asg_name,
+        desired_capacity,
+        max_size,
+        min_size,
+        scheduled_action_name=None,
+        start_time=None,
+        end_time=None,
+        recurrence=None
+    ):
+        def make_int(value):
+            return int(value) if value is not None else value
+
+        max_size = make_int(max_size)
+        min_size = make_int(min_size)
+        desired_capacity = make_int(desired_capacity)
+
+        group = FakeScheduledAction(
+            asg_name=asg_name,
+            desired_capacity=desired_capacity,
+            max_size=max_size,
+            min_size=min_size,
+            scheduled_action_name=scheduled_action_name,
+            start_time=None,
+            end_time=None,
+            recurrence=None
+        )
+        self.autoscaling_groups[asg_name] = group
+
+        return group
 
     def create_auto_scaling_group(
         self,

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -102,6 +102,20 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(CREATE_AUTOSCALING_GROUP_TEMPLATE)
         return template.render()
 
+    def create_auto_scaling_scheduled_action(self):
+        self.autoscaling_backend.create_auto_scaling_scheduled_action(
+            asg_name=self._get_param("AutoScalingGroupName"),
+            desired_capacity=self._get_int_param("DesiredCapacity"),
+            max_size=self._get_int_param("MaxSize"),
+            min_size=self._get_int_param("MinSize"),
+            scheduled_action_name="SAHIL",
+            start_time=start_time=self._get_param("StartTime"),
+            end_time=end_time=self._get_param("EndTime"),
+            recurrence=self._get_param("Recurrence")
+        )
+        template = self.response_template(CREATE_AUTOSCALING_SCHEDULED_ACTION_TEMPLATE)
+        return template.render()
+
     @amz_crc32
     @amzn_request_id
     def attach_instances(self):
@@ -312,6 +326,7 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(EXECUTE_POLICY_TEMPLATE)
         return template.render()
 
+    def describe_
     @amz_crc32
     @amzn_request_id
     def attach_load_balancers(self):
@@ -566,6 +581,13 @@ DELETE_LAUNCH_CONFIGURATION_TEMPLATE = """<DeleteLaunchConfigurationResponse xml
     <RequestId>7347261f-97df-11e2-8756-35eEXAMPLE</RequestId>
   </ResponseMetadata>
 </DeleteLaunchConfigurationResponse>"""
+
+CREATE_AUTOSCALING_GROUP_TEMPLATE = """<CreateAutoScalingGroupResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+<ResponseMetadata>
+<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+</ResponseMetadata>
+</CreateAutoScalingGroupResponse>"""
+
 
 CREATE_AUTOSCALING_GROUP_TEMPLATE = """<CreateAutoScalingGroupResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <ResponseMetadata>

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -108,9 +108,9 @@ class AutoScalingResponse(BaseResponse):
             desired_capacity=self._get_int_param("DesiredCapacity"),
             max_size=self._get_int_param("MaxSize"),
             min_size=self._get_int_param("MinSize"),
-            scheduled_action_name="SAHIL",
-            start_time=start_time=self._get_param("StartTime"),
-            end_time=end_time=self._get_param("EndTime"),
+            scheduled_action_name=None,
+            start_time=self._get_param("StartTime"),
+            end_time=self._get_param("EndTime"),
             recurrence=self._get_param("Recurrence")
         )
         template = self.response_template(PUT_SCHEDULED_UPDATE_GROUP_ACTION_TEMPLATE)
@@ -326,7 +326,6 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(EXECUTE_POLICY_TEMPLATE)
         return template.render()
 
-    def describe_
     @amz_crc32
     @amzn_request_id
     def attach_load_balancers(self):

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -102,8 +102,8 @@ class AutoScalingResponse(BaseResponse):
         template = self.response_template(CREATE_AUTOSCALING_GROUP_TEMPLATE)
         return template.render()
 
-    def create_auto_scaling_scheduled_action(self):
-        self.autoscaling_backend.create_auto_scaling_scheduled_action(
+    def put_scheduled_update_group_action(self):
+        self.autoscaling_backend.put_scheduled_update_group_action(
             asg_name=self._get_param("AutoScalingGroupName"),
             desired_capacity=self._get_int_param("DesiredCapacity"),
             max_size=self._get_int_param("MaxSize"),
@@ -113,7 +113,7 @@ class AutoScalingResponse(BaseResponse):
             end_time=end_time=self._get_param("EndTime"),
             recurrence=self._get_param("Recurrence")
         )
-        template = self.response_template(CREATE_AUTOSCALING_SCHEDULED_ACTION_TEMPLATE)
+        template = self.response_template(PUT_SCHEDULED_UPDATE_GROUP_ACTION_TEMPLATE)
         return template.render()
 
     @amz_crc32
@@ -588,12 +588,11 @@ CREATE_AUTOSCALING_GROUP_TEMPLATE = """<CreateAutoScalingGroupResponse xmlns="ht
 </ResponseMetadata>
 </CreateAutoScalingGroupResponse>"""
 
-
-CREATE_AUTOSCALING_GROUP_TEMPLATE = """<CreateAutoScalingGroupResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+PUT_SCHEDULED_UPDATE_GROUP_ACTION_TEMPLATE = """<PutScheduledUpdateGroupActionResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <ResponseMetadata>
-<RequestId>8d798a29-f083-11e1-bdfb-cb223EXAMPLE</RequestId>
+<RequestId></RequestId>
 </ResponseMetadata>
-</CreateAutoScalingGroupResponse>"""
+</PutScheduledUpdateGroupActionResponse>"""
 
 ATTACH_LOAD_BALANCER_TARGET_GROUPS_TEMPLATE = """<AttachLoadBalancerTargetGroupsResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
 <AttachLoadBalancerTargetGroupsResult>

--- a/moto/autoscaling/responses.py
+++ b/moto/autoscaling/responses.py
@@ -104,7 +104,7 @@ class AutoScalingResponse(BaseResponse):
 
     def put_scheduled_update_group_action(self):
         self.autoscaling_backend.put_scheduled_update_group_action(
-            asg_name=self._get_param("AutoScalingGroupName"),
+            name=self._get_param("AutoScalingGroupName"),
             desired_capacity=self._get_int_param("DesiredCapacity"),
             max_size=self._get_int_param("MaxSize"),
             min_size=self._get_int_param("MinSize"),

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -704,6 +704,7 @@ class ResourceMap(collections_abc.Mapping):
 
     def update(self, template, parameters=None):
 
+        print("HEYYYYYYYYYYYYY"))
         resource_names_by_action = self.build_resource_diff(template)
 
         for logical_name in resource_names_by_action["Remove"]:

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -709,6 +709,8 @@ class ResourceMap(collections_abc.Mapping):
         for logical_name in resource_names_by_action["Remove"]:
             resource_json = self._resource_json_map[logical_name]
             resource = self._parsed_resources[logical_name]
+            print(f"\n resource_json: {resource_json}")
+            print(f"\n resource: {resource}")
             # ToDo: Standardize this.
             if hasattr(resource, "physical_resource_id"):
                 resource_name = self._parsed_resources[

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -708,8 +708,8 @@ class ResourceMap(collections_abc.Mapping):
 
         for logical_name in resource_names_by_action["Remove"]:
             resource_json = self._resource_json_map[logical_name]
-            resource = self._parsed_resources[logical_name]
             print(f"\n resource_json: {resource_json}")
+            resource = self._parsed_resources[logical_name]
             print(f"\n resource: {resource}")
             # ToDo: Standardize this.
             if hasattr(resource, "physical_resource_id"):

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -704,7 +704,6 @@ class ResourceMap(collections_abc.Mapping):
 
     def update(self, template, parameters=None):
 
-        print("HEYYYYYYYYYYYYY"))
         resource_names_by_action = self.build_resource_diff(template)
 
         for logical_name in resource_names_by_action["Remove"]:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -10,7 +10,7 @@ from moto.s3 import s3_backend
 from moto.s3.exceptions import S3ClientError
 from moto.core import ACCOUNT_ID
 from .models import cloudformation_backends
-from .exceptions import ValidationError, MissingParameterError
+from .exceptions import ValidationError
 from .utils import yaml_tag_constructor
 
 
@@ -126,8 +126,13 @@ class CloudFormationResponse(BaseResponse):
             )
             return 400, {"status": 400}, template.render(name=stack_name)
 
-        parameters = self._get_params_from_list(parameters_list)
-
+        # Hack dict-comprehension
+        parameters = dict(
+            [
+                (parameter["parameter_key"], parameter["parameter_value"])
+                for parameter in parameters_list
+            ]
+        )
         if template_url:
             stack_body = self._get_stack_from_s3_url(template_url)
         stack_notification_arns = self._get_multi_param("NotificationARNs.member")
@@ -351,22 +356,6 @@ class CloudFormationResponse(BaseResponse):
         template = self.response_template(GET_TEMPLATE_SUMMARY_TEMPLATE)
         return template.render(template_summary=template_summary)
 
-    def _validate_different_update(self, incoming_params, stack_body, old_stack):
-        if incoming_params and stack_body:
-            new_params = self._get_param_values(incoming_params, old_stack.parameters)
-            if old_stack.template == stack_body and old_stack.parameters == new_params:
-                raise ValidationError(
-                    old_stack.name, message=f"Stack [{old_stack.name}] already exists"
-                )
-
-    def _validate_status(self, stack):
-        if stack.status == "ROLLBACK_COMPLETE":
-            raise ValidationError(
-                stack.stack_id,
-                message="Stack:{0} is in ROLLBACK_COMPLETE state and can not "
-                "be updated.".format(stack.stack_id),
-            )
-
     def update_stack(self):
         stack_name = self._get_param("StackName")
         role_arn = self._get_param("RoleARN")
@@ -391,8 +380,13 @@ class CloudFormationResponse(BaseResponse):
             tags = None
 
         stack = self.cloudformation_backend.get_stack(stack_name)
-        self._validate_different_update(incoming_params, stack_body, stack)
-        self._validate_status(stack)
+        if stack.status == "ROLLBACK_COMPLETE":
+            raise ValidationError(
+                stack.stack_id,
+                message="Stack:{0} is in ROLLBACK_COMPLETE state and can not be updated.".format(
+                    stack.stack_id
+                ),
+            )
 
         stack = self.cloudformation_backend.update_stack(
             name=stack_name,

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -10,7 +10,7 @@ from moto.s3 import s3_backend
 from moto.s3.exceptions import S3ClientError
 from moto.core import ACCOUNT_ID
 from .models import cloudformation_backends
-from .exceptions import ValidationError
+from .exceptions import ValidationError, MissingParameterError
 from .utils import yaml_tag_constructor
 
 

--- a/tests/test_autoscaling/test_autoscaling.py
+++ b/tests/test_autoscaling/test_autoscaling.py
@@ -75,6 +75,16 @@ def test_create_autoscaling_group_within_elb():
         ),
     )
 
+    as_client.put_scheduled_update_group_action(
+        "ScheduledActionName": 'string',
+        "StartTime": "2022-07-01T00:00:00Z",
+        "EndTime": "2022-09-01T00:00:00Z",
+        "Recurrence": 'string',
+        "MinSize": 10,
+        "MaxSize": 12,
+        "DesiredCapacity": 9,
+    )
+
     group = as_client.describe_auto_scaling_groups()["AutoScalingGroups"][0]
     group["AutoScalingGroupName"].should.equal("tester_group")
     set(group["AvailabilityZones"]).should.equal(set(["us-east-1a", "us-east-1b"]))

--- a/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_crud_boto3.py
@@ -1180,42 +1180,7 @@ def test_update_stack_fail_missing_new_parameter():
 
 
 @mock_cloudformation
-def test_update_stack_fail_update_same_template_body():
-
-    name = "update_stack_with_previous_value"
-    cf_conn = boto3.client("cloudformation", region_name="us-east-1")
-    params = [
-        {"ParameterKey": "TagName", "ParameterValue": "foo"},
-        {"ParameterKey": "TagDescription", "ParameterValue": "bar"},
-    ]
-
-    cf_conn.create_stack(
-        StackName=name, TemplateBody=dummy_template_yaml_with_ref, Parameters=params
-    )
-
-    with pytest.raises(ClientError) as exp:
-        cf_conn.update_stack(
-            StackName=name, TemplateBody=dummy_template_yaml_with_ref, Parameters=params
-        )
-    exp_err = exp.value.response.get("Error")
-    exp_metadata = exp.value.response.get("ResponseMetadata")
-
-    exp_err.get("Code").should.equal("ValidationError")
-    exp_err.get("Message").should.equal(f"Stack [{name}] already exists")
-    exp_metadata.get("HTTPStatusCode").should.equal(400)
-
-    cf_conn.update_stack(
-        StackName=name,
-        TemplateBody=dummy_template_yaml_with_ref,
-        Parameters=[
-            {"ParameterKey": "TagName", "ParameterValue": "new_foo"},
-            {"ParameterKey": "TagDescription", "ParameterValue": "new_bar"},
-        ],
-    )
-
-
-@mock_cloudformation
-def test_update_stack_deleted_resources_can_reference_deleted_parameters():
+def test_boto3_update_stack_deleted_resources_can_reference_deleted_parameters():
 
     name = "update_stack_deleted_resources_can_reference_deleted_parameters"
 

--- a/tests/test_cloudformation/test_cloudformation_stack_integration.py
+++ b/tests/test_cloudformation/test_cloudformation_stack_integration.py
@@ -1433,6 +1433,18 @@ def test_autoscaling_propagate_tags():
                     "InstanceType": "t2.medium",
                 },
             },
+            "ScheduledAction": {
+                "Type" : "AWS::AutoScaling::ScheduledAction",
+                "Properties" : {
+                    "AutoScalingGroupName" : "test-scaling-group",
+                    "DesiredCapacity" : 10,
+                    "EndTime" : "2022-08-01T00:00:00Z",
+                    "MaxSize" : 15,
+                    "MinSize" : 5,
+                    "Recurrence" : "* * * * *",
+                    "StartTime" : "2022-07-01T00:00:00Z",
+                }
+            },
         },
     }
     boto3.client("cloudformation", "us-east-1").create_stack(


### PR DESCRIPTION
Provide the ability for cloudformation backend to create/update/delete resources of type `AWS::AutoScaling::ScheduledAction`.

__NOTE__: At this time the logic does not include creation of scheduled actions in autoscaling backend, it only allows for cloudformation backend to manage resources.